### PR TITLE
Http santizing task for all http log files inside ./HTTP.

### DIFF
--- a/Analyzer/Run-ExchangeLogAnalyzer.ps1
+++ b/Analyzer/Run-ExchangeLogAnalyzer.ps1
@@ -28,7 +28,39 @@ switch ($LogType) {
             $i++
         }
      }
-    "Http" {  }
+    "Http" { 
+        try{
+            if(!(Test-Path .\HTTP)){
+                Write-Host "No HTTP folder found. Please create a folder 'HTTP' and paste all collected data inside."
+                Exit
+            }
+            if(!(Test-Path .\HTTP\Sanitized)){
+                New-Item -ItemType Directory -Path .\HTTP\Sanitized -ErrorAction Stop
+            }
+            $folders = Get-ChildItem .\HTTP -ErrorAction Stop | where FullName -NotMatch "sanitized"
+            $y = 1
+            foreach($folder in $folders){
+                Write-Progress -Activity "Processing folder $($folder.Name)" -Status "Folder $y of $($folders.Length)" -Id 1 -PercentComplete (($y/$folders.Length)*100)
+                $logFiles = Get-ChildItem ".\HTTP\$($folder.Name)" -Recurse -ErrorAction Stop
+                New-Item -ItemType Directory -Path ".\HTTP\Sanitized\$($folder.Name)" -ErrorAction Stop
+                $i = 1
+                foreach($item in $logFiles){
+                    Write-Progress -Activity "Sanitizing file $($item.Name)" -Status "File $i of $($logFiles.Length)" -Id 2 -ParentId 1 -PercentComplete (($i/$logFiles.Length)*100)
+                    if($item.GetType().Name -eq "FileInfo"){
+                        (Get-Content $item -ErrorAction Stop).Replace("#Fields: ", "") | Select-String -Pattern '^#' -NotMatch | %{$_.Line} | Out-File $item.FullName.Replace("\HTTP\","\HTTP\Sanitized\").Replace(".log","_sanitized_$($folder.Name).log")
+                        #Get-Content $item.FullName.Replace("\HTTP\","\HTTP\Sanitized\").Replace(".log","_sanitizedTEMP.log") | Select-String -Pattern '^#' -NotMatch | Out-File $item.FullName.Replace("\HTTP\","\HTTP\Sanitized\").Replace("_sanitizedTEMP.log","_$($folder.Name)_sanitized.log") -ErrorAction Stop
+                        #Remove-Item $item.FullName.Replace("\HTTP\","\HTTP\Sanitized\").Replace(".log","_sanitizedTEMP.log") -ErrorAction Stop
+                    }
+                    $i++
+                }
+                $y++
+            }
+        }
+        catch{
+            Write-Host $_.Exception.Message -ForegroundColor Yellow
+        }
+        
+     }
     "Smtp" {  }
     Default {}
 }


### PR DESCRIPTION
First http log sanitization version:
 - Reads logs from ./HTTP folder
 - Detects a folder per server in using patter ./HTTP/<servername: folder and get all logs inside
 - Remove all lines starting with '#'
 - Created a ./HTTP/Sanitized/<servername> folder for each source folder in ./HTTP folder and writes down each sanitized log.