### PR TITLE
Pop fix first blank line

### DIFF
--- a/Analyzer/Run-ExchangeLogAnalyzer.ps1
+++ b/Analyzer/Run-ExchangeLogAnalyzer.ps1
@@ -25,7 +25,6 @@ switch ($LogType) {
                     Write-Progress -Activity "Sanitizing file $($item.Name)" -Status "File $i of $($logFiles.Length)" -Id 2 -ParentId 1 -PercentComplete (($i/$logFiles.Length)*100)
                     if($item.GetType().Name -eq "FileInfo"){
                         Get-Content $item -ErrorAction Stop | Select-String -Pattern '^#' -NotMatch -ErrorAction Stop | %{$_.Line} | Out-File $item.FullName.Replace("\POP\","\POP\Sanitized\").Replace(".LOG","_sanitized_$($folder.Name).LOG")
-                        Remove-Item $item -Confirm:$false
                     }
                     $i++
                 }


### PR DESCRIPTION
 - No more first blank line in sanitized files.
 - Stop support .zip files. Now the .\POP directory should have a folder per server where the folder name should be the server name in the format .\POP\<servername> with all log files already extracted inside respective server folder name
 - All final files placed inside .\POP\Sanitized\<servername> folder
 - Don't remove original log files to make it easier to process it again without the need to copy once again inside .\POP directory.